### PR TITLE
Bugfix/msp 3553 hookable accepted args

### DIFF
--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -28,6 +28,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Themosis\Core\Bootstrap\EnvironmentLoader;
 use Themosis\Core\Events\LocaleUpdated;
+use Themosis\Hook\Hookable;
 use Themosis\Route\RouteServiceProvider;
 
 class Application extends Container implements ApplicationContract, CachesConfiguration, CachesRoutes, HttpKernelInterface
@@ -1288,6 +1289,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         // Build a "Hookable" instance.
         // Hookable instances must extend the "Hookable" class.
+        /** @var Hookable $instance */
         $instance = new $hook($this);
         $hooks = (array) $instance->hook;
 
@@ -1296,7 +1298,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
         }
 
         if (! empty($hooks)) {
-            $this['action']->add($hooks, [$instance, 'register'], $instance->priority);
+            $this['action']->add($hooks, [$instance, 'register'], $instance->priority, $instance->acceptedArgs);
         } else {
             $instance->register();
         }

--- a/src/Hook/Hookable.php
+++ b/src/Hook/Hookable.php
@@ -6,20 +6,10 @@ use Illuminate\Contracts\Foundation\Application;
 
 class Hookable
 {
-    /**
-     * @var Application
-     */
-    protected $app;
-
-    /**
-     * @var string|array
-     */
-    public $hook;
-
-    /**
-     * @var int
-     */
-    public $priority = 10;
+    protected Application $app;
+    public string|array $hook;
+    public int $priority = 10;
+    public int $acceptedArgs = 3;
 
     public function __construct(Application $app)
     {

--- a/src/Hook/Hookable.php
+++ b/src/Hook/Hookable.php
@@ -6,10 +6,25 @@ use Illuminate\Contracts\Foundation\Application;
 
 class Hookable
 {
-    protected Application $app;
-    public string|array $hook;
-    public int $priority = 10;
-    public int $acceptedArgs = 3;
+    /**
+     * @var Application
+     */
+    protected $app;
+
+    /**
+     * @var string|array
+     */
+    public $hook;
+
+    /**
+     * @var int
+     */
+    public $priority = 10;
+
+    /**
+     * @var int
+     */
+    public $acceptedArgs = 3;
 
     public function __construct(Application $app)
     {

--- a/tests/Core/HooksRepositoryTest.php
+++ b/tests/Core/HooksRepositoryTest.php
@@ -3,11 +3,20 @@
 namespace Themosis\Tests\Core;
 
 use PHPUnit\Framework\TestCase;
+use Themosis\Core\Application;
 use Themosis\Core\HooksRepository;
+use Themosis\Hook\ActionBuilder;
 use Themosis\Hook\Hookable;
 
 class HooksRepositoryTest extends TestCase
 {
+    protected Application $app;
+
+    public function setUp(): void
+    {
+        $this->app = new Application();
+    }
+
     public function testHookablesClassesAreRegistered()
     {
         $app = $this->getMockBuilder(\Themosis\Core\Application::class)
@@ -19,14 +28,33 @@ class HooksRepositoryTest extends TestCase
 
         (new HooksRepository($app))->load([
             'Some\Namespace\Hookable',
-            \Themosis\Tests\Core\MyActions::class,
+            MyActions::class,
         ]);
+    }
+
+    public function testCorrectAcceptedArgsCount()
+    {
+        $action = $this->getMockBuilder(ActionBuilder::class)
+                       ->setConstructorArgs([$this->app])
+                       ->setMethods(['addAction'])
+                       ->getMock();
+
+        $action->expects($this->once())
+               ->method('addAction')
+               ->with('someHook', [new MyActions($this->app), 'register'], 10, 4);
+
+        $this->app->offsetSet('action', $action);
+        $this->app->registerHook(MyActions::class);
     }
 }
 
 class MyActions extends Hookable
 {
-    public function register()
+    public $hook = 'someHook';
+    public $priority = 10;
+    public $acceptedArgs = 4;
+
+    public function register($one, $two, $three, $four)
     {
     }
 }

--- a/tests/Hook/AFilterClassForTest.php
+++ b/tests/Hook/AFilterClassForTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Themosis\Tests\Hook;
+
 class AFilterClassForTest
 {
     public function custom_filter()

--- a/tests/Hook/ActionTest.php
+++ b/tests/Hook/ActionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Themosis\Tests\Hook;
+
 use PHPUnit\Framework\TestCase;
 use Themosis\Core\Application;
 use Themosis\Hook\ActionBuilder;
@@ -53,7 +55,7 @@ class ActionTest extends TestCase
             ->method('addAction');
 
         // Run the action
-        $action->add('a_custom_action', 'AnActionClassForTest', 5, 4);
+        $action->add('a_custom_action', AnActionClassForTest::class, 5, 4);
 
         // Check if this action is registered.
         $this->assertTrue($action->exists('a_custom_action'));
@@ -69,7 +71,7 @@ class ActionTest extends TestCase
         $this->assertEquals(4, $action->getCallback('a_custom_action')[2]);
 
         // Run the action if pre-defined method.
-        $action->add('another_hook', 'AnActionClassForTest@customName');
+        $action->add('another_hook', '\Themosis\Tests\Hook\AnActionClassForTest@customName');
 
         // Check this action is registered.
         $this->assertTrue($action->exists('another_hook'));
@@ -111,7 +113,7 @@ class ActionTest extends TestCase
 
         // Check if callback is this instance.
         $this->assertEquals([$this, 'afterSetup'], $action->getCallback('after-custom-setup')[0]);
-        $this->assertInstanceOf('ActionTest', $action->getCallback('after-custom-setup')[0][0]);
+        $this->assertInstanceOf(ActionTest::class, $action->getCallback('after-custom-setup')[0][0]);
     }
 
     public function testActionIsRanWithoutArguments()

--- a/tests/Hook/AnActionClassForTest.php
+++ b/tests/Hook/AnActionClassForTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Themosis\Tests\Hook;
+
 class AnActionClassForTest
 {
     public function init()

--- a/tests/Hook/FilterTest.php
+++ b/tests/Hook/FilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Themosis\Tests\Hook;
+
 use PHPUnit\Framework\TestCase;
 use Themosis\Core\Application;
 use Themosis\Hook\FilterBuilder;
@@ -52,7 +54,7 @@ class FilterTest extends TestCase
         $filter->expects($this->exactly(2))
             ->method('addFilter');
 
-        $filter->add('custom-filter', 'AFilterClassForTest', 4, 2);
+        $filter->add('custom-filter', AFilterClassForTest::class, 4, 2);
 
         // Check if this filter is registered.
         $this->assertTrue($filter->exists('custom-filter'));
@@ -76,7 +78,7 @@ class FilterTest extends TestCase
         $this->assertEquals(2, $filter->getCallback('custom-filter')[2]);
 
         // Run filter with pre-defined method name.
-        $filter->add('another-filter', 'AFilterClassForTest@awesomeFilter');
+        $filter->add('another-filter', '\Themosis\Tests\Hook\AFilterClassForTest@awesomeFilter');
 
         // Check this filter is registered.
         $this->assertTrue($filter->exists('another-filter'));


### PR DESCRIPTION
If you create an hookable class with more than three arguments for the `register`-method the application will break, because `accepted_args` is default set to `3`