### PR TITLE
MSP-3956: replaced offset handling with settings object

### DIFF
--- a/src/Page/Page.php
+++ b/src/Page/Page.php
@@ -628,6 +628,9 @@ class Page implements PageInterface
 
         if ($setting->getName() === $lastSetting->getName() && ! $this->errors) {
             $this->addSettingsSuccessMessage($this->getSlug());
+
+            // Let's add a "fake" error to avoid duplicate success messages.
+            $this->errors++;
         }
 
         $setting->setValue($value);


### PR DESCRIPTION
At the moment the configured page with its settings and fields does not function as desired. The offset breaks because [sanitizeSettings()](https://github.com/spring-media/themosis-framework/blob/4.0/src/Page/Page.php#L608) is called twice if the options do not exist in the db see also this [core bug](https://core.trac.wordpress.org/ticket/21989).

We replaced the offset logic with a concrete settings object.