### PR TITLE
Bugfix/msp 5515 route cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "themosis-framework",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "A WordPress framework.",
   "directories": {
     "test": "resources/assets/js/tests"

--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -26,7 +26,7 @@ class Application extends \Illuminate\Foundation\Application implements
     /**
      * Themosis framework version.
      */
-    public const THEMOSIS_VERSION = '12.0.0';
+    public const THEMOSIS_VERSION = '12.0.1';
 
     /**
      * Application textdomain.

--- a/src/Route/CompiledRouteCollection.php
+++ b/src/Route/CompiledRouteCollection.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Themosis\Route;
+
+use Illuminate\Http\Request;
+
+class CompiledRouteCollection extends \Illuminate\Routing\CompiledRouteCollection
+{
+    public function match(Request $request) {
+        $routes = $this->get($request->getMethod());
+        $route = $this->matchAgainstRoutes($routes, $request);
+
+        return is_null($route)
+            ? parent::match($request)
+            : $this->handleMatchedRoute($request, $route);
+    }
+}

--- a/src/Route/RouteCollection.php
+++ b/src/Route/RouteCollection.php
@@ -9,10 +9,11 @@ class RouteCollection extends IlluminateRouteCollection
     /**
      * Add the given route to the arrays of routes.
      *
-     * @param  \Illuminate\Routing\Route  $route
+     * @param Route $route
      */
-    protected function addToCollections($route)
+    protected function addToCollections($route): void
     {
+        $methods = $route->methods();
         $domainAndUri = $route->getDomain().$route->uri();
 
         if ($route->hasCondition() && ! empty($route->getConditionParameters())) {
@@ -23,6 +24,6 @@ class RouteCollection extends IlluminateRouteCollection
             $this->routes[$method][$domainAndUri] = $route;
         }
 
-        $this->allRoutes[$method.$domainAndUri] = $route;
+        $this->allRoutes[implode('|', $methods).$domainAndUri] = $route;
     }
 }

--- a/src/Route/Router.php
+++ b/src/Route/Router.php
@@ -69,6 +69,15 @@ class Router extends IlluminateRouter
         return parent::findRoute($request);
     }
 
+    public function setCompiledRoutes(array $routes): void
+    {
+        $this->routes = new CompiledRouteCollection($routes['compiled'], $routes['attributes'])
+            ->setRouter($this)
+            ->setContainer($this->container);
+
+        $this->container->instance('routes', $this->routes);
+    }
+
     /**
      * Setup WordPress conditions.
      */


### PR DESCRIPTION
### Context
- `php artisan route:cache` creates `bootstrap/cache/routes-v7.php` which will handled by `Illuminate/Routing/CompiledRouteCollection.php` and not by the old `Themosis/Route/RouteCollection`. This results in a "405 Method not allowed", because the WordPress routes could not be found

### Changes
* Added a new class `CompiledRouteCollection` in `src/Route/CompiledRouteCollection.php` that extends Laravel's `CompiledRouteCollection` and overrides the `match` method to prioritize custom route matching before falling back to the parent implementation.
* Introduced a `setCompiledRoutes` method in `Router` (`src/Route/Router.php`) to make use of the `CompiledRouteCollection`
